### PR TITLE
Typos and updated dependencies

### DIFF
--- a/Deliverable5.5/README.md
+++ b/Deliverable5.5/README.md
@@ -50,12 +50,14 @@ The local execution of this demonstration requires the following software compon
   The easiest option is to download a [static linux binary](https://download.lammps.org/static/). Alternatively, it can be compiled from the source code using `make` or `cmake` following the instructions [here](https://docs.lammps.org/Install.html). Note that the LAMMPS binary in the YAML scripts is called `lmp_23Jun22`. You can either create a symbolic link with that name to any other valid LAMMPS binary file, or replace the string `command: "lmp_23Jun22"` in the files [`workflow_nopipes.yaml`](./demo1/workflow_nopipes.yaml), [`workflow_1oteapi.yaml`](./demo1/workflow_1oteapi.yaml), and [`workflow_2oteapi.yaml`](./demo1/workflow_2oteapi.yaml) with the name of your local LAMMPS binary.
 
 
-* Clone the [OpenModel Public](https://github.com/H2020-OpenModel/Public) repository and install the python modules including `ontoflow`, `execflow`, and `oteapi-dlite`. Open a terminal and execute:
+* Clone the [OpenModel Public](https://github.com/H2020-OpenModel/Public) repository and install the python modules including `ontoflow` and `execflow`. Open a terminal and execute:
   ```bash
   git clone https://github.com/H2020-OpenModel/Public.git
   cd Public/Deliverable5.5
   pip install .
   ```
+NB! Until ExecFlow and OntoFlow have been made public it might be easier to just clone and pip install execflow and ontoflow separately before the step above.
+
   To avoid changing the names of local files stored in the repository, absolute paths with root `/tmp/Deliverable5.5` have been used. Independently from where your repository is stored, create the following link from a terminal:
   
   ```bash

--- a/Deliverable5.5/demo1/run_workflow.py
+++ b/Deliverable5.5/demo1/run_workflow.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+"""Script to run AiiDA declarative chain"""
 import aiida
 aiida.load_profile()
 import os

--- a/Deliverable5.5/demo1/run_workflow_pipes.py
+++ b/Deliverable5.5/demo1/run_workflow_pipes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+"""Script to run AiiDA declarative chain"""
 import aiida
 
 aiida.load_profile()

--- a/Deliverable5.5/demo1/workflow_1oteapi.yaml
+++ b/Deliverable5.5/demo1/workflow_1oteapi.yaml
@@ -7,7 +7,7 @@ steps:
   - workflow: execflow.oteapipipeline
     inputs:
       pipeline:
-        $ref: file:pipeline_waterdensity.yml
+        $ref: file:pipeline_waterdensity.yaml
       from_cuds:
         - lt_input 
     postprocess:

--- a/Deliverable5.5/demo1/workflow_2oteapi.yaml
+++ b/Deliverable5.5/demo1/workflow_2oteapi.yaml
@@ -7,7 +7,7 @@ steps:
   - workflow: execflow.oteapipipeline
     inputs:
       pipeline:
-        $ref: file:pipeline_waterdensity.yml
+        $ref: file:pipeline_waterdensity.yaml
       from_cuds:
         - parameters_input
         - lt_input 
@@ -23,7 +23,7 @@ steps:
   - workflow: execflow.oteapipipeline
     inputs:
       pipeline:
-        $ref: file:pipeline_dependencies.yml
+        $ref: file:pipeline_dependencies.yaml
       from_cuds:
         - moltemplate_input 
     postprocess:

--- a/Deliverable5.5/pyproject.toml
+++ b/Deliverable5.5/pyproject.toml
@@ -19,10 +19,8 @@ classifiers = [
 requires-python = '>=3.8'
 
 dependencies = [
-	'aiida-core',
     'ontoflow@git+https://github.com/H2020-OpenModel/OntoFlow@9c76d78',
     'execflow@git+https://github.com/H2020-OpenModel/ExecFlow',
-    'oteapi-dlite@git+https://github.com/EMMC-ASBL/oteapi-dlite',
 ]
 
 [project.urls]


### PR DESCRIPTION
oteapi-dlite and aiida-core are already dependencies of execflow. No need to specify here.

made the workflowrunners executable.