### PR TITLE
Updated lammpsparser to only calculate density from the last ran loop

### DIFF
--- a/Deliverable5.5/execflowdemo/calculations/lammps.py
+++ b/Deliverable5.5/execflowdemo/calculations/lammps.py
@@ -11,15 +11,14 @@ def parse_density(log: "orm.SinglefileData") -> "Dict[str, orm.Float]":
     filename_stdout = log
     stdout = log.get_content()
 
-    nconv = 0
-    sum_density = 0.0
-
     data_lines = stdout.split('\n')
     istep, idensity = -1, -1
     for line in data_lines:
         if "Loop time of" in line:
-            break
+            istep, idensity = -1, -1
         if "Step" in line:
+            nconv = 0
+            sum_density = 0.0
             header = line.split()
             istep = header.index("Step")
             idensity = header.index("Density")

--- a/Deliverable5.5/pyproject.toml
+++ b/Deliverable5.5/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = '>=3.8'
 
 dependencies = [
-    'ontoflow@git+https://github.com/H2020-OpenModel/OntoFlow@9c76d78',
+    'ontoflow@git+https://github.com/H2020-OpenModel/OntoFlow',
     'execflow@git+https://github.com/H2020-OpenModel/ExecFlow',
 ]
 


### PR DESCRIPTION
In some outputfiles there are several runs after the other (equilibration first and then others afterwards).

This is to ensure that the only last cycle (which should be production run) is taken into account when calculating density.